### PR TITLE
add intro component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,10 @@ import Intro from "@/components/organisms/Intro";
 export default function Home() {
   return (
     <Layout>
-      <Intro />
+      <Intro
+        title="タイトル"
+        description="テキストが入ります。テキストが入ります。テキストが入ります。"
+      />
     </Layout>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 // import Image from "next/image";
 import "./reset.css";
 import Layout from "@/components/templates/Layout";
+import Intro from "@/components/organisms/Intro";
 
 export default function Home() {
   return (
     <Layout>
-      <h1>テスト</h1>
+      <Intro />
     </Layout>
   );
 }

--- a/src/components/organisms/Intro/index.tsx
+++ b/src/components/organisms/Intro/index.tsx
@@ -21,7 +21,7 @@ const IntroInner = styled.div`
   justify-content: space-between;
   flex-direction: column;
   margin-inline: auto;
-  @media screen and (min-width:  ${theme.breakPoints.md}px) {
+  @media screen and (min-width: ${theme.breakPoints.md}) {
     flex-direction: row;
     align-items: center;
     max-width: 1040px;

--- a/src/components/organisms/Intro/index.tsx
+++ b/src/components/organisms/Intro/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import styled from 'styled-components';
+import { theme } from '@/themes';
 
 interface IntroProps {
   title: string;
@@ -8,7 +9,7 @@ interface IntroProps {
 }
 
 const IntroRoot = styled.section`
-  background-color: #f2f2f2;
+  background-color: ${theme.colors.primary};
   display: flex;
   padding: 16px;
 `
@@ -20,7 +21,7 @@ const IntroInner = styled.div`
   justify-content: space-between;
   flex-direction: column;
   margin-inline: auto;
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width:  ${theme.breakPoints.md}px) {
     flex-direction: row;
     align-items: center;
     max-width: 1040px;
@@ -28,7 +29,7 @@ const IntroInner = styled.div`
 `
 
 const Heading = styled.h1`
-  font-size: 24px;
+  font-size: ${theme.fontSizes.extraLarge}px;
 `
 
 const Intro = ({ title, description }: IntroProps) => {

--- a/src/components/organisms/Intro/index.tsx
+++ b/src/components/organisms/Intro/index.tsx
@@ -1,8 +1,13 @@
-"use client";
+'use client';
 
 import styled from 'styled-components';
 
-const IntroRoot = styled.div`
+interface IntroProps {
+  title: string;
+  description: string;
+}
+
+const IntroRoot = styled.section`
   background-color: #f2f2f2;
   display: flex;
   padding: 16px;
@@ -26,12 +31,12 @@ const Heading = styled.h1`
   font-size: 24px;
 `
 
-const Intro = () => {
+const Intro = ({ title, description }: IntroProps) => {
   return (
-    <IntroRoot>
+    <IntroRoot aria-labelledby='intro-title'>
       <IntroInner>
-        <Heading>タイトル</Heading>
-        <p>テキストが入ります</p>
+        <Heading id='intro-title'>{title}</Heading>
+        <p>{description}</p>
       </IntroInner>
     </IntroRoot>
   )

--- a/src/components/organisms/Intro/index.tsx
+++ b/src/components/organisms/Intro/index.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import styled from 'styled-components';
+
+const IntroRoot = styled.div`
+  background-color: #f2f2f2;
+  display: flex;
+  padding: 16px;
+`
+
+const IntroInner = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-direction: column;
+  margin-inline: auto;
+  @media screen and (min-width: 768px) {
+    flex-direction: row;
+    align-items: center;
+    max-width: 1040px;
+  }
+`
+
+const Heading = styled.h1`
+  font-size: 24px;
+`
+
+const Intro = () => {
+  return (
+    <IntroRoot>
+      <IntroInner>
+        <Heading>タイトル</Heading>
+        <p>テキストが入ります</p>
+      </IntroInner>
+    </IntroRoot>
+  )
+}
+
+export default Intro;

--- a/src/themes/breakPoints.ts
+++ b/src/themes/breakPoints.ts
@@ -1,0 +1,11 @@
+/**
+ * プロジェクト内で使用するブレイクポイント
+ */
+const breakPoints = {
+  sm: '640px', // 640px以上
+  md: '768px', // 768px以上
+  lg: '1024px', // 1024px以上
+  xl: '1280px', // 1280px以上
+}
+
+export default breakPoints;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,7 +1,9 @@
 import colors from "./colors";
 import fontSizes from "./fontSizes";
+import breakPoints from "./breakPoints";
 
 export const theme = {
   colors,
   fontSizes,
+  breakPoints,
 } as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- 静的なヘッダーから新しい紹介コンポーネントに切り替え、ホームページのヘッダーに「タイトル」と「テキストが入ります」が表示されるようになりました。

- **スタイル**
	- レスポンシブ対応のレイアウトを採用し、画面サイズに応じた柔軟で現代的なデザインに改善しました。

- **テーマ**
	- 新しいレスポンシブデザインのブレークポイントがテーマに追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->